### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for the KITE shield
 paragraph=Enables user-friendly control of the KITE shield and various wireless modules.
 category=Communication
 url=https://github.com/jgromes/KiteLib
-architecture=*
+architectures=*
 includes=KiteLib.h


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format